### PR TITLE
fix: add AZURE_OPENAI_EMBEDDING_DEPLOYMENT to generated .env

### DIFF
--- a/challenge-0/get-keys.sh
+++ b/challenge-0/get-keys.sh
@@ -353,6 +353,7 @@ echo "AZURE_OPENAI_SERVICE_NAME=\"$aiFoundryHubName\"" >> ../.env
 echo "AZURE_OPENAI_ENDPOINT=\"$aiFoundryEndpoint\"" >> ../.env
 echo "AZURE_OPENAI_KEY=\"$aiFoundryKey\"" >> ../.env
 echo "AZURE_OPENAI_DEPLOYMENT_NAME=\"gpt-4.1-mini\"" >> ../.env
+echo "AZURE_OPENAI_EMBEDDING_DEPLOYMENT=\"text-embedding-ada-002\"" >> ../.env
 echo "AZURE_OPENAI_API_VERSION=\"2024-12-01-preview\"" >> ../.env
 echo "MODEL_DEPLOYMENT_NAME=\"gpt-4.1-mini\"" >> ../.env
 


### PR DESCRIPTION
## Problem

I was running `challenge-1/scripts/policiesprocessing.ipynb` and got this error:

```
Error generating embedding: Unsupported data type
```

The problem is `challenge-0/get-keys.sh` makes a `.env` file but it does not add `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` variable. So the notebook dont know which embedding model to use.

## Fix

I added one line to `get-keys.sh`:

```bash
echo "AZURE_OPENAI_EMBEDDING_DEPLOYMENT=\"text-embedding-ada-002\"" >> ../.env
```

This line goes after `AZURE_OPENAI_DEPLOYMENT_NAME`.

## Testing

After this fix i run the notebook from top. It worked. 0 embedding errors.

<img width="1015" height="504" alt="image" src="https://github.com/user-attachments/assets/78e2705f-7033-45de-8e5a-7ac7eaa1b4cf" />

<img width="1061" height="304" alt="image" src="https://github.com/user-attachments/assets/5e4d68b2-c78f-4003-899a-390e9970b6da" />

