### PR TITLE
fix: use correct 'agent_reference' key in extra_body for Responses API

### DIFF
--- a/challenge-6/agents/coverage_validation_agent.py
+++ b/challenge-6/agents/coverage_validation_agent.py
@@ -144,7 +144,7 @@ Analyze the claim against the policy coverage and produce the coverage determina
 
             response = openai_client.responses.create(
                 input=user_query,
-                extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
+                extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
             )
 
             response_text = response.output_text.strip()

--- a/challenge-6/agents/policy_matching_agent.py
+++ b/challenge-6/agents/policy_matching_agent.py
@@ -264,7 +264,7 @@ Return the structured JSON coverage summary."""
 
             response = openai_client.responses.create(
                 input=user_query,
-                extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
+                extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
             )
 
             response_text = response.output_text.strip()


### PR DESCRIPTION
The `extra_body` parameter in challenge-6 agents was using `"agent"` as the key, but the Responses API expects `"agent_reference"`. This caused requests to fail when invoking agents.

### Changes
- `challenge-6/agents/coverage_validation_agent.py`: `extra_body={"agent": ...}` → `extra_body={"agent_reference": ...}`
- `challenge-6/agents/policy_matching_agent.py`: `extra_body={"agent": ...}` → `extra_body={"agent_reference": ...}`